### PR TITLE
Add paired t-test, add documentation, and add some unit tests

### DIFF
--- a/man/prec_meandiff.Rd
+++ b/man/prec_meandiff.Rd
@@ -12,7 +12,7 @@ prec_meandiff(
   r = 1,
   conf.width = NULL,
   conf.level = 0.95,
-  variance = c("equal", "unequal"),
+  variance = c("equal", "unequal", "paired"),
   ...
 )
 }
@@ -31,7 +31,7 @@ prec_meandiff(
 
 \item{conf.level}{confidence level.}
 
-\item{variance}{\code{equal} (\emph{default}) or \code{unequal} variance.}
+\item{variance}{\code{equal} (\emph{default}), \code{unequal} variance, or \code{paired} for paired tests.}
 
 \item{...}{other options to uniroot (e.g. \code{tol})}
 }
@@ -46,6 +46,12 @@ provided mean difference and standard deviations.
 \details{
 Exactly one of the parameters \code{n} or \code{conf.width} must be passed as NULL,
 and that parameter is determined from the other.
+
+If \code{variance} is \code{paired}, this means that we're attempting a paired test,
+  and the standard deviation in \code{sd1} is the standard deviation of the differences. As such,
+  \code{delta} will also be the mean differences. If this option is selected, \code{r} has to be 1 and
+  \code{sd2} has to be equal to \code{sd1} (\emph{default}) since we only use \code{sd1} and \code{n1}
+  for the computation.
 }
 \examples{
 # mean difference of 5, SD of 2.5, CI width with 20 participants assuming equal variances
@@ -53,4 +59,6 @@ prec_meandiff(delta = 5, sd1 = 2.5, n1 = 20, var = "equal")
 # mean difference of 5, SD of 2.5, number of participants for a CI width of 3,
 #  assuming equal variances
 prec_meandiff(delta = 5, sd1 = 2.5, conf.width = 3, var = "equal")
+# paired t-test using sd1 to specify the standard dev. of differences
+prec_meandiff(delta = 2, sd1 = 2.5, conf.width = 0.5, variance = "paired")
 }

--- a/tests/testthat/test-differences.R
+++ b/tests/testthat/test-differences.R
@@ -44,6 +44,10 @@ test_that("errors", {
   expect_error(prec_meandiff(2, .5, conf.width = .1, variance = "equal"), NA)
   expect_error(prec_meandiff(2, .5, n1 = 50, variance = "unequal"), NA)
   expect_error(prec_meandiff(2, .5, conf.width = .1, variance = "unequal"), NA)
+  # paired difference error tests
+  expect_error(prec_meandiff(2, 0.5, n1 = 50, r = 2, variance = "paired"))
+  expect_message(prec_meandiff(delta = 2, n1 = 50, sd1 = 2, sd2 = 5, r = 1,
+                               variance = "paired"), "will not be used since the standard dev. of")
 
   expect_error(prec_riskdiff())
   expect_error(prec_riskdiff(n = 100))
@@ -84,19 +88,31 @@ test_that("errors", {
 })
 
 ### Mean difference
+test_that("paired mean diff n = R ref", {
+  # fix conf.width, compute N
+  x <- rnorm(50, mean = 1, sd = 2)
+  y <- rnorm(50, mean = 2, sd = 3)
+  ref_test <- t.test(x, y, paired = TRUE, conf.level = 0.95)
+  ref_width <- abs(ref_test$conf.int[1] - ref_test$conf.int[2])
+  ex <- prec_meandiff(delta = 1, sd1 = sd(x - y),
+                      r = 1, conf.width = ref_width,
+                      conf.level = 0.95, variance = "paired")
+  expect_equal(ex$n1, 50, tolerance = .001, scale = 1)
+})
+
 test_that("mean diff n = stata", {
-  
+
   #     . ciwidth twomeans 0 5, probwidth(0.5) width(.5) sd(3)
   #     note: command arguments (control- and experimental-group mean estimates) do not
   #     affect computations and are used only for display
-  #     
+  #
   #     Performing iteration ...
-  #     
+  #
   #     Estimated sample sizes for a two-means-difference CI
   #     Student's t two-sided CI assuming sd1 = sd2 = sd
-  # 
+  #
   # Study parameters:
-  # 
+  #
   #         level =     95.00
   #      Pr_width =    0.5000
   #         width =    0.5000
@@ -104,30 +120,30 @@ test_that("mean diff n = stata", {
   #            m2 =    5.0000
   #          diff =    5.0000
   #            sd =    3.0000
-  # 
+  #
   # Estimated sample sizes:
-  # 
+  #
   #             N =     2,216
   #   N per group =     1,108
-  
+
   ex <- prec_meandiff(delta = 5, sd1 = 3, sd2 = 3, r = 1, conf.width = .5, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$n1 , 1108 , tolerance = 3, scale = 1)
-  
+
   ex <- prec_meandiff(delta = 5, sd1 = 3, sd2 = 3, r = 1, n = 1108, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$conf.width , .5 , tolerance = .001, scale = 1)
 })
 
 test_that("mean diff n = stata", {
-  
+
   # . ciwidth twomeans 0 5, width(.5) sd1(3) sd2(2) knownsds
   # note: command arguments (control- and experimental-group mean estimates) do not
   # affect computations and are used only for display
-  # 
+  #
   # Estimated sample sizes for a two-means-difference CI
   # Normal two-sided CI
-  # 
+  #
   # Study parameters:
-  #   
+  #
   #   level =     95.00
   # width =    0.5000
   # m1 =    0.0000
@@ -135,30 +151,42 @@ test_that("mean diff n = stata", {
   # diff =    5.0000
   # sd1 =    3.0000
   # sd2 =    2.0000
-  # 
+  #
   # Estimated sample sizes:
-  #   
+  #
   #   N =     1,600
   # N per group =       800
-  
+
   ex <- prec_meandiff(delta = 5, sd1 = 3, sd2 = 2, r = 1, conf.width = 0.5, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$n1 , 800, tolerance = 3, scale = 1)
-  
+
   ex <- prec_meandiff(delta = 5, sd1 = 3, sd2 = 2, r = 1, n = 800, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$conf.width , .5, tolerance = .001, scale = 1)
 })
 
+test_that("paired mean diff conf int = R ref", {
+  # fix N, compute conf.width
+  x <- rnorm(50, mean = 1, sd = 2)
+  y <- rnorm(50, mean = 2, sd = 3)
+  ref_test <- t.test(x, y, paired = TRUE, conf.level = 0.95)
+  ref_width <- abs(ref_test$conf.int[1] - ref_test$conf.int[2])
+  ex <- prec_meandiff(delta = 1, sd1 = sd(x - y),
+                      r = 1, n1 = 50, conf.level = 0.95, variance = "paired")
+  expect_equal(ex$conf.width, ref_width, tolerance = .001, scale = 1)
+
+})
+
 test_that("mean diff conf int = stata", {
-  
+
   #     . ciwidth twomeans 0 5, n(160) sd(2) probwidth(0.5)
   #     note: command arguments (control- and experimental-group mean estimates) do not
   #     affect computations and are used only for display
-  #     
+  #
   #     Estimated width for a two-means-difference CI
   #     Student's t two-sided CI assuming sd1 = sd2 = sd
-  # 
+  #
   # Study parameters:
-  # 
+  #
   #         level =     95.00
   #             N =       160
   #   N per group =        80
@@ -167,14 +195,14 @@ test_that("mean diff conf int = stata", {
   #            m2 =    5.0000
   #          diff =    5.0000
   #            sd =    2.0000
-  # 
+  #
   # Estimated width:
-  # 
+  #
   #         width =    1.2465
-  
+
   ex <- prec_meandiff(delta = 10, sd1 = 2, sd2 = 2, r = 1, n = 80, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$conf.width , 1.2465 , tolerance = .05, scale = 1)
-  
+
   ex <- prec_meandiff(delta = 10, sd1 = 2, sd2 = 2, r = 1, conf.width = 1.2465, conf.level = 0.95, variance = 'equal')
   expect_equal(ex$n1 , 80 , tolerance = 2, scale = 1)
 })
@@ -183,15 +211,15 @@ test_that("mean diff conf int = stata", {
 ### Risk difference
 
 test_that("risk diff conf int ac = stata", {
-  
+
   # . rdcii 45 15 105 135
-  # 
+  #
   # Confidence intervals for risk difference
-  # 
+  #
   # Risk for unexposed (p0): 0.100
   # Risk for exposed (p1): 0.300
   # Risk difference (p1 - p0): 0.200
-  # 
+  #
   # -----------------------------------------
   #   Method      [95% Conf. Interval]
   # -----------------------------------------
@@ -201,27 +229,27 @@ test_that("risk diff conf int ac = stata", {
   # Miettinen-Nurminen    0.112         0.289
   # . disp r(lb_ac)
   # .10964857
-  # 
+  #
   # . disp r(ub_ac)
   # .28529424
 
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, n1 = 150, conf.level = 0.95, method = 'ac')
   expect_equal(c(ex$lwr, ex$upr) , c(.10964857, .28529424), tolerance = .01, scale = 1)
-  
+
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, conf.width = .28529424-.10964857, conf.level = 0.95, method = 'ac')
   expect_equal(ex$n1, 150, tolerance = 1, scale = 1)
-})  
+})
 
 test_that("risk diff conf int newcombe = stata", {
-  
+
   # . rdcii 45 15 105 135
-  # 
+  #
   # Confidence intervals for risk difference
-  # 
+  #
   # Risk for unexposed (p0): 0.100
   # Risk for exposed (p1): 0.300
   # Risk difference (p1 - p0): 0.200
-  # 
+  #
   # -----------------------------------------
   #   Method      [95% Conf. Interval]
   # -----------------------------------------
@@ -231,27 +259,27 @@ test_that("risk diff conf int newcombe = stata", {
   # Miettinen-Nurminen    0.112         0.289
   # . disp r(lb_ne)
   # .11065088
-  # 
+  #
   # . disp r(ub_ne)
   # .28658921
-  
+
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, n1 = 150, conf.level = 0.95, method = 'newcombe')
   expect_equal(c(ex$lwr, ex$upr) , c(.11065088, .28658921), tolerance = .001, scale = 1)
-  
+
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, conf.width = .28658921-.11065088, conf.level = 0.95, method = 'newcombe')
   expect_equal(ex$n1, 150, tolerance = 1, scale = 1)
-})  
+})
 
 test_that("risk diff conf int nm = stata", {
-  
+
   # .   rdcii 45 15 105 135
-  # 
+  #
   # Confidence intervals for risk difference
-  # 
+  #
   # Risk for unexposed (p0): 0.100
   # Risk for exposed (p1): 0.300
   # Risk difference (p1 - p0): 0.200
-  # 
+  #
   # -----------------------------------------
   #   Method      [95% Conf. Interval]
   # -----------------------------------------
@@ -261,13 +289,13 @@ test_that("risk diff conf int nm = stata", {
   # Miettinen-Nurminen    0.112         0.289
   # . disp r(lb_mn)
   # .11200421
-  # 
+  #
   # . disp r(ub_mn)
   # .28854354
-  
+
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, n1 = 150, conf.level = 0.95, method = 'mn')
   expect_equal(c(ex$lwr, ex$upr) , c(.11200421, .28854354), tolerance = .001, scale = 1)
-  
+
   ex <- prec_riskdiff(p1 = 0.3, p2 = 0.1, r = 1, conf.width = .28854354-.11200421, conf.level = 0.95, method = 'mn')
   expect_equal(ex$n1, 150, tolerance = 1, scale = 1)
 })
@@ -276,16 +304,16 @@ test_that("risk diff conf int nm = stata", {
 
 ### Odds ratio
 test_that("odds ratio conf int woolf = stata", {
-  
+
   # Ref. Fagerland 2015
   # Confidence interval
   #                           Lower Upper  Length
   #Woolf logit                 0.99    74    4.31
   #Gart adjusted logit         0.98    38    3.65
   #Independence-smoothed logit 0.99    60    4.11
-  
+
   # . csi 7 1 27 33 , or woolf
-  # 
+  #
   #                  |   Exposed   Unexposed  |      Total
   #         ---------+------------------------+------------
   #            Cases |         7           1  |          8
@@ -297,54 +325,54 @@ test_that("odds ratio conf int woolf = stata", {
   #                  |                        |
   #                  |      Point estimate    |    [95% Conf. Interval]
   #                  |------------------------+------------------------
-  #  Risk difference |         .1764706       |    .0291694    .3237718 
-  #       Risk ratio |                7       |    .9096055    53.86951 
-  #  Attr. frac. ex. |         .8571429       |   -.0993777    .9814366 
+  #  Risk difference |         .1764706       |    .0291694    .3237718
+  #       Risk ratio |                7       |    .9096055    53.86951
+  #  Attr. frac. ex. |         .8571429       |   -.0993777    .9814366
   #  Attr. frac. pop |              .75       |
   #       Odds ratio |         8.555556       |    .9904903     73.9003 (Woolf)
   #   +-------------------------------------------------
   #   chi2(1) =     5.10  Pr>chi2 = 0.0239
-  # 
-  
+  #
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, n1 = 34, r = 1, conf.width = NULL, conf.level = 0.95, method = "woolf")
   expect_equal(c(ex$lwr, ex$upr) , c(0.99, 74), tolerance = .1, scale = 1)
   expect_equal(c(ex$lwr, ex$upr) , c(.9904903, 73.9003), tolerance = .0001, scale = 1)
-  
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, r = 1, conf.width = 73.9003-.9904903, conf.level = 0.95, method = "woolf")
   expect_equal(ex$n1 , 34, tolerance = 1, scale = 1)
 })
 
 test_that("odds ratio conf int gart = stata", {
-  
+
   # Ref. Fagerland 2015
   # Confidence interval
   #                           Lower Upper  Length
   #Woolf logit                 0.99    74    4.31
   #Gart adjusted logit         0.98    38    3.65
-  #Independence-smoothed logit 0.99    60    4.11  
-  
+  #Independence-smoothed logit 0.99    60    4.11
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, n1 = 34, r = 1, conf.width = NULL, conf.level = 0.95, method = "gart")
   expect_equal(ex$lwr , 0.98, tolerance = .01, scale = 1)
   expect_equal(ex$upr , 38, tolerance = .5, scale = 1)
-  
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, r = 1, conf.width = 38-.98, conf.level = 0.95, method = "gart")
   expect_equal(ex$n1 , 34, tolerance = 1, scale = 1)
-  
+
 })
 
 test_that("odds ratio conf int indip smooth = stata", {
-  
+
     # Ref. Fagerland 2015
     # Confidence interval
     #                           Lower Upper  Length
     #Woolf logit                 0.99    74    4.31
     #Gart adjusted logit         0.98    38    3.65
     #Independence-smoothed logit 0.99    60    4.11
-  
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, n1 = 34, r = 1, conf.width = NULL, conf.level = 0.95, method = "indip_smooth")
   expect_equal(ex$lwr , 0.99, tolerance = .01, scale = 1)
   expect_equal(ex$upr , 60, tolerance = .5, scale = 1)
-  
+
   ex <- prec_or(p1 = 7/34, p2 = 1/34, r = 1, conf.width = 60-.99, conf.level = 0.95, method = "indip_smooth")
   expect_equal(ex$n1 , 34, tolerance = 1, scale = 1)
 })
@@ -356,7 +384,7 @@ test_that("Fagerland et al. (2015), Table 5", {
   r <- 1
   method <- "katz"
   p <- prec_riskratio(p1 = p1, p2 = p2, n1 = n1, r = r, method = method)
-  
+
   expect_equal(class(p), "presize")
   expect_equal(p$p1, p1)
   expect_equal(p$p2, p2)
@@ -365,14 +393,14 @@ test_that("Fagerland et al. (2015), Table 5", {
   expect_equivalent(p$rr, 7)
   expect_equivalent(round(p$lwr, 2), .91)
   expect_equivalent(round(p$upr, 0), 54)
-  
+
   p1 <- 7/34
   p2 <- 1/34
   n1 <- 34
   r <- 1
   method <- "koopman"
   p <- prec_riskratio(p1 = p1, p2 = p2, n1 = n1, r = r, method = method)
-  
+
   expect_equal(class(p), "presize")
   expect_equal(p$p1, p1)
   expect_equal(p$p2, p2)
@@ -381,7 +409,7 @@ test_that("Fagerland et al. (2015), Table 5", {
   expect_equivalent(p$rr, 7)
   expect_equivalent(round(p$lwr, 1), 1.2)
   expect_equivalent(round(p$upr, 0), 43)
-  
+
 })
 
 context("rateratio")
@@ -393,9 +421,9 @@ test_that("inverse", {
 })
 
 test_that("rateratio = stata outputs", {
-  
+
   # . iri 30 60 54308 51477
-  # 
+  #
   #                  |   Exposed   Unexposed  |      Total
   # -----------------+------------------------+------------
   #            Cases |        30          60  |         90
@@ -406,19 +434,19 @@ test_that("rateratio = stata outputs", {
   #                  |                        |
   #                  |      Point estimate    |    [95% Conf. Interval]
   #                  |------------------------+------------------------
-  #  Inc. rate diff. |        -.0006132       |   -.0009682   -.0002581 
+  #  Inc. rate diff. |        -.0006132       |   -.0009682   -.0002581
   #  Inc. rate ratio |         .4739357       |    .2951285    .7464182 (exact)
   #  Prev. frac. ex. |         .5260643       |    .2535818    .7048715 (exact)
   #  Prev. frac. pop |         .2700714       |
   #                  +-------------------------------------------------
   #   (midp)   Pr(k<=30) =                    0.0003 (exact)
   #   (midp) 2*Pr(k<=30) =                    0.0006 (exact)
-  
+
   ex <- prec_rateratio(n1 = 54308, rate1 = 30/54308, rate2 = 60/51477, r = 51477/54308)
   expect_equal(c(ex$lwr, ex$upr), c(.2951285, .7464182) , tolerance = .05, scale = 1)
 
   ex <- prec_rateratio(rate1 = 30/54308, rate2 = 60/51477, prec.level = 2.4, r = 51477/54308)
   expect_equal(ex$n1, 54308, tolerance = 150, scale = 1) # 150 patient-year difference is less than 0.3% difference
-  
+
 })
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request to presize! -->

**Summary**: This pull request is for simple support for paired t-tests in `prec_meandiff`. In this case, a paired t-test of difference-in-means would compute the confidence interval around the mean (paired) differences using the standard deviation of the (paired) differences. This value would be specified in `sd1`. As such, we do not use `sd2` and expect `n1` and `n2` to be equal (`r` = 1). A source for the equation is [here](https://sphweb.bumc.bu.edu/otlt/mph-modules/bs/sas/sas4-onesamplettest/SAS4-OneSampleTtest7.html). 

$$
\bar{d} = t_{\alpha/2, n - 1} \cdot \frac{SD_{\bar{d}}}{\sqrt{n}}
$$

I attempted to affect the code base minimally by specifying this "paired" option as part of the `variance` argument. This is because there isn't really a paired t-test with unequal variances since the test is concerned with [the variance of differences](https://stats.stackexchange.com/questions/409248/paired-t-test-means-that-the-variances-of-the-2-samples-are-the-same). As such, it makes sense for `paired` to be a separate option to `equal` and `unequal`.   

Note: I did not update anything related to `pkgdown`. 

<!-- Describe the motivation behind your PR - refer to issues where relevant -->

A couple of reminders:
- [x] unit tests written
- [x] continuous integration (github actions) passing? -- I checked R CMD Check locally





